### PR TITLE
Post-deadline README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Live Demo](https://img.shields.io/badge/Live_Demo-Visit_Site-blue)](https://adverse-event-visualize-mu.vercel.app)
 
 ## Overview
-The Adverse Event Analyzer is a web application built with Next.js and Material-UI (MUI) to help healthcare professionals analyze drug-related adverse event reports using the FDA's OpenFDA Adverse Events API. This tool provides actionable insights through search, filtering, metrics, and time trend visualization, enabling users to understand key metrics (e.g., total reports, deaths, hospitalizations) and trends for specific drugs. Developed as a take-home interview assignment, the project was completed within a 1-hour, 1.5-hour maximum recording window, prioritizing production-readiness over extensive features.
+The Adverse Event Analyzer is a web application built with Next.js, Tailwind CSS, and Shadcn UI to help healthcare professionals analyze drug-related adverse event reports using the FDA's OpenFDA Adverse Events API. This tool provides actionable insights through search, filtering, metrics, and time trend visualization, enabling users to understand key metrics (e.g., total reports, deaths, hospitalizations) and trends for specific drugs. Developed as a take-home interview assignment, the project was completed within a 1.5-hour window, prioritizing production-readiness over extensive features.
 
 ## Features
 - **Drug Search**: Search for adverse events by drug name (e.g., "DURAGESIC-100").
@@ -12,11 +12,12 @@ The Adverse Event Analyzer is a web application built with Next.js and Material-
 - **Time Trend Visualization**: Visualize adverse event counts by year using a bar chart.
 
 ## Project Structure
-- `/app`: Next.js App Router directory with `page.jsx`, `layout.jsx`, and API routes (`/api/adverse-events/route.js`).
+- `/app`: Next.js App Router directory with `page.tsx`, `layout.tsx`, and API routes (`/api/adverse-events/route.ts`).
 - `/components`: Reusable components (`SearchBar.tsx`, `FilterDropdown.tsx`, `MetricsDisplay.tsx`, `TrendChart.tsx`).
 - `/public`: Static assets (if needed).
-- `package.json`: Project dependencies (Next.js, MUI, Chart.js, etc.).
+- `package.json`: Project dependencies (Next.js, Tailwind CSS, Shadcn UI, Chart.js, etc.).
 - `README.md`: This documentation.
+- `/docs`: Additional documentation used as reference by LLMs
 
 ## Getting Started
 
@@ -27,7 +28,7 @@ The Adverse Event Analyzer is a web application built with Next.js and Material-
 ### Installation
 1. Clone the repository:
    ```bash
-   git clone <repository-url>
+   git clone https://github.com/israelvicars/adverse-event-visualize
    cd adverse-event-analyzer
    ```
 
@@ -54,36 +55,39 @@ The Adverse Event Analyzer is a web application built with Next.js and Material-
 * A live deployment is available at [adverse-event-visualize-mu.vercel.app](https://adverse-event-visualize-mu.vercel.app)
 
 ## Development Process
-This project was developed within a 1-hour window (recorded under 1.5 hours) using the following approach:
+This project was developed within a 1.5-hour window using the following plan:
 
-* **Setup (0:00-0:10)**: Created a Next.js app with MUI, set up basic layout, and installed dependencies (Next.js, MUI, Chart.js).
+* **Setup (0:00-0:10)**: Created a Next.js app with TypeScript, set up Tailwind CSS and Shadcn UI components, and installed dependencies.
 * **API Integration & Search (0:10-0:30)**: Built a server-side route handler (/api/adverse-events) to fetch OpenFDA data, added SearchBar.tsx for drug search.
 * **Seriousness Filter & Metrics (0:30-0:45)**: Implemented FilterDropdown.tsx and MetricsDisplay.tsx to filter by seriousness and display metrics (total, deaths, hospitalizations, etc.).
 * **Time Trend Visualization (0:45-0:55)**: Added TrendChart.tsx for a bar chart of events by year using Chart.js.
 * **Testing & Final Tweaks (0:55-1:00)**: Tested with sample drugs (e.g., "DURAGESIC-100", "ASPIRIN"), fixed bugs, and ensured functionality.
+* **Research & Overage (1:00-1:30)**: Extra time dedicated to explore public API and for things to go wrong 
 
 I used Cursor as my IDE, an LLM (Grok 3) for brainstorming and code suggestions, and git for version control (commits marked milestones 1-5). The screen recording captures this process, submitted within 4 hours of receiving the challenge.
 
 ## Technical Choices & Tradeoffs
 * **Next.js with App Router**: Chosen for rapid setup, server-side rendering, and API routes, ensuring production-readiness. Tradeoff: Limited time prevented exploring other frameworks like Remix or Svelte.
-* **Material-UI (MUI)**: Selected for its professional, healthcare-friendly styling and quick component integration. Tradeoff: Default MUI styling was prioritized over custom CSS for speed, potentially limiting unique design.
+* **Tailwind CSS & Shadcn UI**: Selected for rapid development with utility-first CSS and accessible, customizable components. Tradeoff: Learning curve for utility classes, but offset by excellent documentation and type safety.
 * **Chart.js for Visualization**: Lightweight and easy to integrate, but lacks advanced features (e.g., tooltips, animations) due to time constraints.
 * **No Caching or Error Handling**: Omitted for simplicity; in production, I'd add caching (e.g., React Query) and robust error boundaries.
-* **API Limit=100**: Caps results for performance, but limits comprehensive data analysis—ideal for demo but not scalable without pagination.
+* **API Limit=1000**: Caps results for performance, but limits comprehensive data analysis—ideal for demo but not scalable without pagination.
 
 ## Production-Readiness Considerations
 * **Server-Side API Calls**: Reduces client-side load, but no rate limiting or retry logic was added due to time.
-* **Responsive Design**: MUI ensures mobile-friendliness, but extensive testing was skipped.
+* **Responsive Design**: Tailwind's mobile-first approach ensures responsiveness, but extensive testing was skipped.
 * **Security**: No API keys needed, but encodeURIComponent sanitizes inputs—production would require more robust validation.
 * **Testing**: Basic manual testing was done; unit tests (e.g., Jest, React Testing Library) were omitted for time but are critical for production.
 
 ## Future Improvements (If More Time)
+* **Theme Customization**: Leverage Tailwind's theme configuration for custom branding.
 * **Advanced Filtering**: Add pharmacological class or route filters from the API.
 * **Pagination**: Implement skip and limit for larger datasets.
 * **Error Handling**: Add loading states, retry logic, and user-friendly error messages.
 * **Data Caching**: Use SWR or React Query for better performance.
 * **Accessibility**: Enhance ARIA labels and keyboard navigation for WCAG compliance.
 * **UI Polish**: Add custom animations, tooltips for charts, and a more detailed layout.
+* **Component Library**: Expand Shadcn UI component usage for consistent UI patterns.
 
 ## Documentation
 
@@ -91,7 +95,7 @@ For more detailed information about the project, please refer to the documentati
 
 * [API Documentation](/docs/API.md) - Details about the API implementation and OpenFDA integration
 * [Architecture Overview](/docs/ARCHITECTURE.md) - System architecture and design decisions
-* [Component Documentation](/docs/COMPONENT.md) - Component structure and implementation details
+* [Component Documentation](/docs/COMPONENTS.md) - Component structure and implementation details
 * [Project Milestones](/docs/MILESTONES.md) - Development timeline and milestone achievements
 * [Product Requirements](/docs/PRD.md) - Product requirements and specifications
 * [Styling Guide](/docs/STYLING.md) - Style guidelines and UI/UX documentation

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ The Adverse Event Analyzer is a web application built with Next.js, Tailwind CSS
 - `README.md`: This documentation.
 - `/docs`: Additional documentation used as reference by LLMs
 
+## Documentation
+
+For more detailed information about the project, please refer to the specifications in the /docs directory, which were generated to serve as references and guides for the LLM:
+
+* [API Documentation](/docs/API.md) - Details about the API implementation and OpenFDA integration
+* [Architecture Overview](/docs/ARCHITECTURE.md) - System architecture and design decisions
+* [Component Documentation](/docs/COMPONENTS.md) - Component structure and implementation details
+* [Project Milestones](/docs/MILESTONES.md) - Development timeline and milestone achievements
+* [Product Requirements](/docs/PRD.md) - Product requirements and specifications
+* [Styling Guide](/docs/STYLING.md) - Style guidelines and UI/UX documentation
+
 ## Getting Started
 
 ### Prerequisites
@@ -62,7 +73,7 @@ This project was developed within a 1.5-hour window using the following plan:
 * **Seriousness Filter & Metrics (0:30-0:45)**: Implemented FilterDropdown.tsx and MetricsDisplay.tsx to filter by seriousness and display metrics (total, deaths, hospitalizations, etc.).
 * **Time Trend Visualization (0:45-0:55)**: Added TrendChart.tsx for a bar chart of events by year using Chart.js.
 * **Testing & Final Tweaks (0:55-1:00)**: Tested with sample drugs (e.g., "DURAGESIC-100", "ASPIRIN"), fixed bugs, and ensured functionality.
-* **Research & Overage (1:00-1:30)**: Extra time dedicated to explore public API and for things to go wrong 
+* **Research & Overage (1:00-1:30)**: Extra time dedicated to explore public API and for things to go wrong.
 
 I used Cursor as my IDE, an LLM (Grok 3) for brainstorming and code suggestions, and git for version control (commits marked milestones 1-5). The screen recording captures this process, submitted within 4 hours of receiving the challenge.
 
@@ -88,14 +99,3 @@ I used Cursor as my IDE, an LLM (Grok 3) for brainstorming and code suggestions,
 * **Accessibility**: Enhance ARIA labels and keyboard navigation for WCAG compliance.
 * **UI Polish**: Add custom animations, tooltips for charts, and a more detailed layout.
 * **Component Library**: Expand Shadcn UI component usage for consistent UI patterns.
-
-## Documentation
-
-For more detailed information about the project, please refer to the documentation in the `/docs` directory:
-
-* [API Documentation](/docs/API.md) - Details about the API implementation and OpenFDA integration
-* [Architecture Overview](/docs/ARCHITECTURE.md) - System architecture and design decisions
-* [Component Documentation](/docs/COMPONENTS.md) - Component structure and implementation details
-* [Project Milestones](/docs/MILESTONES.md) - Development timeline and milestone achievements
-* [Product Requirements](/docs/PRD.md) - Product requirements and specifications
-* [Styling Guide](/docs/STYLING.md) - Style guidelines and UI/UX documentation


### PR DESCRIPTION
I found some inaccuracies in the README that I missed in my rush to finish. 

* Material-UI versus Tailwind+Shadcn (I originally spec'd for MUI, but my implementation failed. I tried to change too much at once and then backtracked to project defaults.)
* TypeScript versus JavaScript
* API Limit = 1000 (Started at 100, but 1000 performed fine.)

Other minor changes made for clarity. **Documentation** section moved up for prominence since it has more detailed project information, and I think there's a lot of relevance to those files for this project since they were used as references and specifications for the LLMs.